### PR TITLE
Create AlwaysEqual.swift

### DIFF
--- a/Sources/Ensemble/Utility/AlwaysEqual.swift
+++ b/Sources/Ensemble/Utility/AlwaysEqual.swift
@@ -1,0 +1,28 @@
+//
+//  AlwaysEqual.swift
+//  
+//
+//  Created by Cole Roberts on 3/1/23.
+//
+
+import Foundation
+
+/// A property wrapper that always returns `true` when compared for equality.
+@propertyWrapper
+public struct AlwaysEqual<Value>: Equatable {
+    
+    /// The wrapped value of the property.
+    public let wrappedValue: Value
+    
+    /// Initializes an instance of `AlwaysEqual`.
+    /// - Parameter wrappedValue: The value to be wrapped.
+    public init(wrappedValue value: Value) {
+        self.wrappedValue = value
+    }
+    
+    /// Compares two instances of `AlwaysEqual` for equality.
+    /// - Returns: `true`.
+    public static func == (lhs: AlwaysEqual<Value>, rhs: AlwaysEqual<Value>) -> Bool {
+        true
+    }
+}


### PR DESCRIPTION
Adds `AlwaysEqual` property wrapper which is a simple utility wrapper for use in a Reducer. `Reducing.State` requires `Equatable` conformance for all properties and this change allows other types to be used, even if the underlying value doesn't make use of `Equatable`. 

### Usage
```swift
struct Foo {
    var bar: Bar
}

struct Foo: Reducing {
    struct State: Equatable {
        @AlwaysEqual var foo: Foo
    }
}
```